### PR TITLE
simple readme change to check sonarqube config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,10 @@ jobs:
     with:
       project_key: flexbase-eng_http-client-middleware
     secrets: inherit
+
+  publish:
+    needs: coverage
+    uses: flexbase-eng/.github/.github/workflows/typescript.publish.npm.yml@main
+    with:
+      tag: beta
+    secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,4 @@ jobs:
     uses: flexbase-eng/.github/.github/workflows/typescript.sonarcloud.yml@main
     with:
       project_key: flexbase-eng_http-client-middleware
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-  publish:
-    needs: coverage
-    uses: flexbase-eng/.github/.github/workflows/typescript.publish.npm.yml@main
-    with:
-      tag: beta
-    secrets:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,5 +19,4 @@ jobs:
   publish:
     needs: coverage
     uses: flexbase-eng/.github/.github/workflows/typescript.publish.npm.yml@main
-    secrets:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,7 @@ jobs:
     uses: flexbase-eng/.github/.github/workflows/typescript.sonarcloud.yml@main
     with:
       project_key: flexbase-eng_http-client-middleware
-    secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    secrets: inherit
 
   publish:
     needs: coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # http-client-middleware
 
-This is a middleware package to ease http authentication
+This is a middleware package to ease http authentication.
 
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=flexbase-eng_http-client-middleware&metric=coverage)](https://sonarcloud.io/summary/new_code?id=flexbase-eng_http-client-middleware) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=flexbase-eng_http-client-middleware&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=flexbase-eng_http-client-middleware)
 


### PR DESCRIPTION
- testing sonarcloud config with workflow update
- once merged, i believe the sonarcloud bot on PRs will have a correct baseline diff.
- github shared workflow updated to fix coverage file issues

coverage report in sonarcloud now:
<img width="640" alt="Screen Shot 2022-06-22 at 6 40 05 AM" src="https://user-images.githubusercontent.com/8620384/175009857-3a564632-73a4-4b0f-a6e5-d36f442230e9.png">


