### PR TITLE
bump to 1.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/http-client-middleware",
-  "version": "1.9.0",
+  "version": "1.9.3",
   "description": "Http client middleware",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
tested a lot on a temporary branch to ensure `beta` builds would work, along with updates to publishing on `main`. Bumping above the current 1.9.1 and 1.9.2 tests in branch, to bring main up to 1.9.3 and avoid collisions.